### PR TITLE
Added a renderChild lambda for use in radio-group mixin, allow params…

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# EditorConfig is awesome: http://EditorConfig.org
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 4

--- a/README.md
+++ b/README.md
@@ -93,3 +93,4 @@ textarea
 - `legendClassName`: Applied as a class name to HTML `legend` attribute.
 - `toggle`: Can be used to toggle the display of the HTML element with a matching `id`. See [passports-frontend-toolkit](https://github.com/UKHomeOffice/passports-frontend-toolkit/blob/master/assets/javascript/progressive-reveal.js) for details.
 - `attributes`: A hash of key/value pairs applicable to a HTML `textarea` field. Each key/value is assigned as an attribute of the `textarea`. For example `spellcheck="true"`.
+- `child`: Render a child partial beneath each option in an `optionGroup`. Accepts a custom mustache template string, a custom partial in the format `partials/{your-partial-name}` or a template mixin key which will be rendered within a panel element partial.

--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -29,6 +29,8 @@ module.exports = function (fields, options) {
         sharedTranslationsKey += '.';
     }
 
+    var PANELMIXIN = 'partials/mixins/panel';
+
     var PARTIALS = [
         'partials/forms/input-text-group',
         'partials/forms/input-submit',
@@ -95,25 +97,63 @@ module.exports = function (fields, options) {
             return fields && fields[key] && fields[key][property] ? fields[key][property] : 'fields.' + key + '.' + property;
         };
 
+        /*
+        * Utility function to parse {{x}} args passed to
+        * mustache lambda in a partial.
+        * Only the literal unparsed string including braces
+        * is available to lamba methods used in partials
+        * in this scope by default
+        */
+        var extractKey = function extractKey(key) {
+            // regex to extract x from {{x}}
+            var re = /^\{\{([^\{\}]+)\}\}$/;
+            var match = key.match(re);
+            // extract value and check scope for
+            // corresponding property
+            if (match && match[1] && this[match[1]]) {
+                key = this[match[1]];
+            }
+            return key;
+        };
+
+        /*
+         * helper function which takes a child string which
+         * can either be the name of a partial in the format
+         * partial/{partial-name}, the name of a template mixin
+         * or a raw template string to render
+         */
+        var getTemplate = function getTemplate(child) {
+            var re = /^partials\/(.+)/i;
+            var match = child.match(re);
+            if (match) {
+                return fs.readFileSync(res.locals.partials['partials-' + match[1]] + '.' + viewEngine).toString();
+            } else if (res.locals[child]) {
+                var panelPath = path.join(viewsDirectory, PANELMIXIN + '.' + viewEngine);
+                return fs.readFileSync(panelPath).toString();
+            } else {
+                return child;
+            }
+        };
+
         function inputText(key, extension) {
             var hKey = getTranslationKey(key, 'hint');
             var lKey = getTranslationKey(key, 'label');
             var hint = conditionalTranslate(hKey);
 
             var required = function isRequired() {
-              var r = false;
+                var r = false;
 
-              if (fields[key]) {
-                if (fields[key].required !== undefined) {
-                  return fields[key].required;
-                } else if (fields[key].validate) {
-                  var hasRequiredValidator = _.indexOf(fields[key].validate, 'required') !== -1;
+                if (fields[key]) {
+                    if (fields[key].required !== undefined) {
+                        return fields[key].required;
+                    } else if (fields[key].validate) {
+                        var hasRequiredValidator = _.indexOf(fields[key].validate, 'required') !== -1;
 
-                  return hasRequiredValidator ? true : false;
+                        return hasRequiredValidator ? true : false;
+                    }
                 }
-              }
 
-              return r;
+                return r;
             }();
 
             extension = extension || {};
@@ -155,7 +195,7 @@ module.exports = function (fields, options) {
                 'legendClassName': legendClassName,
                 hint: conditionalTranslate(getTranslationKey(key, 'hint')),
                 'options': _.map(fields[key] && fields[key].options, function (obj) {
-                    var selected = false, label, value, toggle;
+                    var selected = false, label, value, toggle, child;
 
                     if (typeof obj === 'string') {
                         value = obj;
@@ -164,20 +204,50 @@ module.exports = function (fields, options) {
                         value = obj.value;
                         label = obj.label;
                         toggle = obj.toggle;
+                        child = obj.child;
                     }
 
                     if (this.values && this.values[key] !== undefined) {
                         selected = this.values[key] === value;
                     }
 
+                    function getErrorClass() {
+                        return function(k) {
+                            k = extractKey.call(this, k);
+                            if (this.errors && this.errors[k]) {
+                                return 'validation-error';
+                            }
+                            return '';
+                        };
+                    }
+
                     return {
                         label: t(label) || '',
                         value: value,
                         selected: selected,
-                        toggle: toggle
+                        toggle: toggle,
+                        child: child,
+                        getErrorClass: getErrorClass
                     };
                 }, this),
-                className: classNames(key)
+                className: classNames(key),
+                renderChild: function () {
+                    return function () {
+                        if (this.child) {
+                            var templateString = getTemplate(this.child, this.toggle);
+                            var template = Hogan.compile(templateString);
+                            return template.render(_.extend({
+                                renderMixin: function() {
+                                    return function () {
+                                        if (this.child && this[this.child]) {
+                                            return this[this.child]().call(this, this.toggle);
+                                        }
+                                    };
+                                }
+                            }, res.locals, this));
+                        }
+                    };
+                }
             };
         }
 
@@ -200,113 +270,129 @@ module.exports = function (fields, options) {
             });
         }
 
-        res.locals['input-text'] = function () {
-            return function (key) {
-                return compiled['partials/forms/input-text-group'].render(inputText.call(this, key));
-            };
-        };
-
-        res.locals['input-date'] = function () {
-            return function (key) {
-                // Exact unless there is a inexact property against the fields key.
-                var isExact = fields[key] ? fields[key].inexact !== true : true;
-
-                var parts = [],
-                    dayPart, monthPart, yearPart;
-
-                if (isExact) {
-                    dayPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-day', { pattern: '[0-9]*', min: 1, max: 31, maxlength: 2, hintId: key + '-hint', date: true }));
-                    parts.push(dayPart);
+        var mixins = {
+            'input-text': {
+                path: 'partials/forms/input-text-group',
+                renderWith: inputText
+            },
+            'input-text-compound': {
+                path: 'partials/forms/input-text-group',
+                renderWith: inputText,
+                options: {
+                    compound: true
                 }
+            },
+            'input-text-code': {
+                path: 'partials/forms/input-text-group',
+                renderWith: inputText,
+                options: {
+                    className: 'input-code'
+                }
+            },
+            'input-number': {
+                path: 'partials/forms/input-text-group',
+                renderWith: inputText,
+                options: {
+                    pattern: '[0-9]*'
+                }
+            },
+            'input-phone': {
+                path: 'partials/forms/input-text-group',
+                renderWith: inputText,
+                options: {
+                    maxlength: 18
+                }
+            },
+            textarea: {
+                path: 'partials/forms/textarea-group',
+                renderWith: inputText
+            },
+            'radio-group': {
+                path: 'partials/forms/radio-group',
+                renderWith: optionGroup
+            },
+            select: {
+                path: 'partials/forms/select',
+                renderWith: inputText,
+                options: optionGroup
+            },
+            checkbox: {
+                path: 'partials/forms/checkbox',
+                renderWith: checkbox
+            },
+            'checkbox-compound': {
+                path: 'partials/forms/checkbox',
+                renderWith: checkbox,
+                options: {
+                    compound: true
+                }
+            },
+            'checkbox-required': {
+                path: 'partials/forms/checkbox',
+                renderWith: checkbox,
+                options: {
+                    required: true
+                }
+            },
+            'input-submit': {
+                handler: function() {
+                    return function (props) {
+                        props = (props || '').split(' ');
+                        var def = 'next',
+                        value = props[0] || def,
+                        id = props[1];
 
-                monthPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-month', { pattern: '[0-9]*', min: 1, max: 12, maxlength: 2, hintId: key + '-hint', date: true }));
-                yearPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-year', { pattern: '[0-9]*', maxlength: 4, hintId: key + '-hint', date: true }));
-                parts = parts.concat(monthPart, yearPart);
+                        var obj = {
+                            value: t('buttons.' + value),
+                            id: id
+                        };
+                        return compiled['partials/forms/input-submit'].render(obj);
+                    };
+                }
+            },
+            'input-date': {
+                handler: function() {
+                    /**
+                    * props: '[value] [id]'
+                    */
+                    return function (key) {
+                        key = extractKey(key);
+                        // Exact unless there is a inexact property against the fields key.
+                        var isExact = fields[key] ? fields[key].inexact !== true : true;
 
-                return parts.join('\n');
-            };
+                        var parts = [],
+                        dayPart, monthPart, yearPart;
+
+                        if (isExact) {
+                            dayPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-day', { pattern: '[0-9]*', min: 1, max: 31, maxlength: 2, hintId: key + '-hint', date: true }));
+                            parts.push(dayPart);
+                        }
+
+                        monthPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-month', { pattern: '[0-9]*', min: 1, max: 12, maxlength: 2, hintId: key + '-hint', date: true }));
+                        yearPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-year', { pattern: '[0-9]*', maxlength: 4, hintId: key + '-hint', date: true }));
+                        parts = parts.concat(monthPart, yearPart);
+
+                        return parts.join('\n');
+                    };
+                }
+            }
         };
 
-        res.locals['input-text-compound'] = function () {
-            return function (key) {
-                var obj = { compound: true };
-                return compiled['partials/forms/input-text-group'].render(inputText.call(this, key, obj));
-            };
-        };
-
-        res.locals['input-text-code'] = function () {
-            return function (key) {
-                return compiled['partials/forms/input-text-group'].render(inputText.call(this, key, { className: 'input-code' }));
-            };
-        };
-
-        res.locals['input-number'] = function () {
-            return function (key) {
-                return compiled['partials/forms/input-text-group'].render(inputText.call(this, key, { pattern: '[0-9]*' }));
-            };
-        };
-
-        res.locals['input-phone'] = function () {
-            return function (key) {
-                return compiled['partials/forms/input-text-group'].render(inputText.call(this, key, { maxlength: 18 }));
-            };
-        };
-
-        res.locals.textarea = function () {
-            return function (key) {
-                return compiled['partials/forms/textarea-group'].render(inputText.call(this, key));
-            };
-        };
-
-        res.locals['radio-group'] = function () {
-            return function (key) {
-                return compiled['partials/forms/radio-group'].render(optionGroup.call(this, key));
-            };
-        };
-
-        res.locals.select = function () {
-            return function (key) {
-                return compiled['partials/forms/select'].render(inputText.call(this, key, optionGroup.call(this, key)));
-            };
-        };
-
-        res.locals.checkbox = function () {
-            return function (key) {
-                return compiled['partials/forms/checkbox'].render(checkbox.call(this, key));
-            };
-        };
-
-        res.locals['checkbox-compound'] = function () {
-            var opts = { compound: true };
-            return function (key) {
-                return compiled['partials/forms/checkbox'].render(checkbox.call(this, key, opts));
-            };
-        };
-
-        res.locals['checkbox-required'] = function () {
-            var opts = { required: true };
-            return function (key) {
-                return compiled['partials/forms/checkbox'].render(checkbox.call(this, key, opts));
-            };
-        };
-
-        /**
-        * props: '[value] [id]'
-        */
-        res.locals['input-submit'] = function () {
-            return function (props) {
-                props = (props || '').split(' ');
-                var def = 'next',
-                    value = props[0] || def,
-                    id = props[1];
-
-                var obj = {
-                    value: t('buttons.' + value),
-                    id: id
+        // loop through mixins object and attach their handler methods
+        // to res.locals['mixin-name'].
+        _.each(mixins, function (mixin, name) {
+            var handler = _.isFunction(mixin.handler) ? mixin.handler : function () {
+                return function (key) {
+                    key = extractKey.call(this, key);
+                    return compiled[mixin.path]
+                        .render(mixin.renderWith.call(this, key, _.isFunction(mixin.options)
+                            ? mixin.options.call(this, key)
+                            : mixin.options
+                        ));
                 };
-                return compiled['partials/forms/input-submit'].render(obj);
             };
-        };
+            res.locals[name] = handler;
+        });
 
         res.locals.currency = function () {
             return function (txt) {

--- a/partials/forms/radio-group.html
+++ b/partials/forms/radio-group.html
@@ -19,5 +19,6 @@
             >
             {{{label}}}
         </label>
+        {{#renderChild}}{{/renderChild}}
     {{/options}}
 </fieldset>

--- a/partials/mixins/panel.html
+++ b/partials/mixins/panel.html
@@ -1,0 +1,5 @@
+<div id="{{toggle}}-panel" class="reveal js-hidden">
+    <div class="panel-indent{{#getErrorClass}}{{toggle}}{{/getErrorClass}}">
+        {{#renderMixin}}{{/renderMixin}}
+    </div>
+</div>

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -1,5 +1,5 @@
 var mixins = require('../lib/template-mixins');
-
+var _ = require('underscore');
 var Hogan = require('hogan.js');
 
 function translate(key) {
@@ -699,13 +699,14 @@ describe('Template Mixins', function () {
                 });
                 middleware(req, res, next);
                 res.locals['radio-group']().call(res.locals, 'field-name');
-                render.should.have.been.calledWith(sinon.match({
-                    options: [{
+                render.should.have.been.calledWith(sinon.match(function (value) {
+                    var obj = value.options[0];
+                    return _.isMatch(obj, {
                         label: 'Foo',
                         value: 'foo',
                         selected: false,
                         toggle: undefined
-                    }]
+                    });
                 }));
             });
 
@@ -781,6 +782,18 @@ describe('Template Mixins', function () {
                 res.locals['radio-group']().call(res.locals, 'field-name');
                 render.should.have.been.calledWithExactly(sinon.match({
                     hint: null
+                }));
+            });
+
+            it('passes a function as renderChild', function () {
+                middleware = mixins({
+                    'field-name': {}
+                });
+                middleware(req, res, next);
+                res.locals['radio-group']().call(res.locals, 'field-name');
+                var renderChild = render.lastCall.args[0].renderChild;
+                render.should.have.been.calledWithExactly(sinon.match(function (value) {
+                    return typeof value.renderChild === 'function'
                 }));
             });
 
@@ -891,10 +904,14 @@ describe('Template Mixins', function () {
                 }, { translate: translate });
                 middleware(req, res, next);
                 res.locals['select']().call(res.locals, 'field-name');
-                render.should.have.been.calledWith(sinon.match({
-                    options: [
-                        { label: '', selected: false, toggle: undefined, value: '' }
-                    ]
+                render.should.have.been.calledWith(sinon.match(function (value) {
+                    var obj = value.options[0]
+                    return _.isMatch(obj, {
+                        label: '',
+                        selected: false,
+                        toggle: undefined,
+                        value: '',
+                    });
                 }));
             });
         });


### PR DESCRIPTION
… to be passed to lambdas through partials.

* Added {{#renderChild}} call to radio-group mixin, called for each child
* Opt in functionality - pass child in field option to include
* child accepts a raw template string, the name of a template mixin (rendered in a panel element) or a custom partial in the format `partials/{your-partial-name}`
* Added support for lambdas to be passed params though partials, these are parsed when detected.
* Refactored mixins to remove repeated code
* Added .editorconfig file with 4 spaces tab setting